### PR TITLE
the context should be a some object rather than nil.

### DIFF
--- a/Example/TableViewBuddyExample/SampleTableViewController1.m
+++ b/Example/TableViewBuddyExample/SampleTableViewController1.m
@@ -147,10 +147,10 @@
                 [row setTitle:@"..." withContext:helper.context];
                 row.tapHandler = ^{
                     ++counter2;
-                    [row_2_2 setTitle:[NSString stringWithFormat:@"Count %ld", (long)counter2] withContext:nil];
+                    [row_2_2 setTitle:[NSString stringWithFormat:@"Count %ld", (long)counter2] withContext:[TBTableDataContext context]];
                     
-                    [row_2_4 setValue:!row_2_4.value withContext:nil];
-                    [row_2_5 setValue:!row_2_5.value withContext:nil];
+                    [row_2_4 setValue:!row_2_4.value withContext:[TBTableDataContext context]];
+                    [row_2_5 setValue:!row_2_5.value withContext:[TBTableDataContext context]];
                 };
             }];
             

--- a/TableViewBuddy/TBCheckRow.m
+++ b/TableViewBuddy/TBCheckRow.m
@@ -73,7 +73,7 @@
 - (void)rowDidTapInTableView:(UITableView *)tableView AtIndexPath:(NSIndexPath *)indexPath {
     [super rowDidTapInTableView:tableView AtIndexPath:indexPath];
     if ([self canChangeValueTo:!self.value]) {
-        [self setValue:!self.value withContext:nil];
+        [self setValue:!self.value withContext:[TBTableDataContext context]];
         if (self.valueChangeHandler != nil) {
             self.valueChangeHandler(self.value);
         }

--- a/TableViewBuddy/TBSingleChoiceNavigationRow.m
+++ b/TableViewBuddy/TBSingleChoiceNavigationRow.m
@@ -115,7 +115,7 @@
                       selectedIndex:weakSelf.selectedIndex
                         withContext:helper.context];
                 section.selectionChangeHandler = ^(NSInteger selectedIndex) {
-                    [weakSelf setSelectedIndex:selectedIndex withContext:nil];
+                    [weakSelf setSelectedIndex:selectedIndex withContext:[TBTableDataContext context]];
                     if (weakSelf.selectionChangeHandler != nil) {
                         weakSelf.selectionChangeHandler(selectedIndex);
                     }

--- a/TableViewBuddy/TBSingleChoiceSection.m
+++ b/TableViewBuddy/TBSingleChoiceSection.m
@@ -77,7 +77,7 @@
 - (void)optionValueSelected:(NSInteger)index {
     if (_selectedIndex >= 0) {
         TBChoiceRow *prevSelectedRow = self.choiceRows[_selectedIndex];
-        [prevSelectedRow setValue:NO withContext:nil];
+        [prevSelectedRow setValue:NO withContext:[TBTableDataContext context]];
     }
     _selectedIndex = index;
     if (self.selectionChangeHandler != nil) {

--- a/TableViewBuddy/TBTableDataContext.h
+++ b/TableViewBuddy/TBTableDataContext.h
@@ -31,6 +31,8 @@
 
 @interface TBTableDataContext : NSObject
 
++ (instancetype)context;
+
 @end
 
 

--- a/TableViewBuddy/TBTableDataContext.m
+++ b/TableViewBuddy/TBTableDataContext.m
@@ -28,6 +28,19 @@
 
 @implementation TBTableDataContext
 
++ (instancetype)context {
+    if ([self class] == [TBTableDataContext class]) {
+        static TBTableDataContext *instance = nil;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            instance = [[TBTableDataContext alloc] init];
+        });
+        return instance;
+    } else {
+        return [[[self class] alloc] init];
+    }
+}
+
 @end
 
 


### PR DESCRIPTION
I think it is better to pass a non-nil TBTableDataContext object as a parameter even if the method doesn't require special context.
In future we may want to store some information to the context but nil cannot hold anything.
However, TBTabledataContext's convenience constructor returns a shared instance rather than creating a new because the class has nothing currently.
