### PR TITLE
In a single choice row, make it possible to specify the navigation controller as a return value of a block

### DIFF
--- a/TableViewBuddy/TBSingleChoiceNavigationRow.h
+++ b/TableViewBuddy/TBSingleChoiceNavigationRow.h
@@ -33,14 +33,23 @@
  This class is a combination of `<TBNavigationRow>` and `<TBSingleChoiceSection>`.
  On the row of this class, the selected option is automatically set to secondary text
  with a disclosure indicator mark.
- When user taps the row, the next view controller with the options list is pushed to its navigation controller.
+ 
+ You must specify your navigation controller by either `<navigationController>` or `<navigationControllerBlock>`.
+ When user taps the row, the next view controller with the options list is pushed to it.
  */
 @interface TBSingleChoiceNavigationRow : TBNavigationRow
 
 /**
  A `UINavigationController` object which is used to push the next view controller.
+ If this property is nil, the navigation controller is retrieved from `<navigationControllerBlock>`.
  */
 @property(nonatomic, weak) UINavigationController *navigationController;
+
+/**
+ A block returns a `UINavigationController` object which is used to push the next view controller.
+ If this property is nil, `<navigationController>` is used for the navigation controller.
+ */
+@property(nonatomic, copy) UINavigationController *(^navigationControllerBlock)();
 
 /**
  A string which is used as the title of the next view controller.

--- a/TableViewBuddy/TBSingleChoiceNavigationRow.m
+++ b/TableViewBuddy/TBSingleChoiceNavigationRow.m
@@ -110,7 +110,11 @@
 }
 
 - (void)showChoiceViewController {
-    NSAssert(self.navigationController != nil, @"please set your navigation controller.");
+    NSAssert(self.navigationController != nil || self.navigationControllerBlock != nil, @"please set your navigation controller.");
+    UINavigationController *navigationController = self.navigationController;
+    if (navigationController == nil) {
+        navigationController = self.navigationControllerBlock();
+    }
 
     TBSingleChoiceNavigationRow * __weak weakSelf = self;
     TBTableViewController *choiceViewController = [[TBTableViewController alloc] initWithStyle:UITableViewStyleGrouped buildTableDataBlock:^TBTableData *(TBTableViewController *vc) {
@@ -134,7 +138,7 @@
     
     choiceViewController.title = self.choiceViewControllerTitle;
     choiceViewController.tableView.accessibilityIdentifier = self.choiceTableAccessibilityIdentifier;
-    [self.navigationController pushViewController:choiceViewController animated:YES];
+    [navigationController pushViewController:choiceViewController animated:YES];
 }
 
 @end


### PR DESCRIPTION
Sometimes the navigation controller is unknown at the time that the table data is configured.
Because of that, it can be difficult to set it to a single choice row.

With this patch, the navigation controller can be specified as a return value of a specified block, and the evaluation of it is deferred until it is really needed.
